### PR TITLE
Fix requirements.txt syntax

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-Python 3+
-Discord.py
+discord.py


### PR DESCRIPTION
added discord.py to requirements.txt Zekrom, requirements.txt is something you can install with pip, if you want to do normal requirements, please write it in the readme.